### PR TITLE
Add DarkModeService with initial test setup

### DIFF
--- a/src/app/services/dark-mode.service.spec.ts
+++ b/src/app/services/dark-mode.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { DarkModeService } from './dark-mode.service';
+
+describe('DarkModeService', () => {
+  let service: DarkModeService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(DarkModeService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/services/dark-mode.service.ts
+++ b/src/app/services/dark-mode.service.ts
@@ -1,0 +1,9 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class DarkModeService {
+
+  constructor() { }
+}


### PR DESCRIPTION
Create a new DarkModeService to support dark mode functionality. Included a basic unit test to verify the service is instantiated correctly. This sets up the foundation for future dark mode features.