### PR TITLE
Add vbumb.sh to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ testem.log
 # System files
 .DS_Store
 Thumbs.db
+
+# Tools
+vbumb.sh


### PR DESCRIPTION
This change ensures the vbumb.sh script is ignored by Git. It prevents accidental commits of this tool to the repository.